### PR TITLE
only dynamically redefine `boundscheck` in `__init__` if it is needed

### DIFF
--- a/src/StrideArraysCore.jl
+++ b/src/StrideArraysCore.jl
@@ -68,7 +68,7 @@ if VERSION >= v"1.7.0" && hasfield(Method, :recursion_relation)
   end
 end
 
-if checkbounds_recompile
+if !checkbounds_recompile
   function __init__()
     ccall(:jl_generating_output, Cint, ()) == 1 && return nothing
     if Base.JLOptions().check_bounds == 1

--- a/src/StrideArraysCore.jl
+++ b/src/StrideArraysCore.jl
@@ -48,6 +48,8 @@ export PtrArray, StrideArray, StaticInt, static, @gc_preserve
   (r::Returns)(args...) = r.x
 end
 
+const checkbounds_recompile = VERSION >= v"1.9.0" && Base.JLOptions().use_pkgimages == 1
+
 @generated static_sizeof(::Type{T}) where {T} =
   :(StaticInt{$(Base.allocatedinline(T) ? sizeof(T) : sizeof(Int))}())
 include("ptr_array.jl")
@@ -66,12 +68,14 @@ if VERSION >= v"1.7.0" && hasfield(Method, :recursion_relation)
   end
 end
 
-function __init__()
-  ccall(:jl_generating_output, Cint, ()) == 1 && return nothing
-  if Base.JLOptions().check_bounds == 1
-    @eval boundscheck() = true
+if checkbounds_recompile
+  function __init__()
+    ccall(:jl_generating_output, Cint, ()) == 1 && return nothing
+    if Base.JLOptions().check_bounds == 1
+      @eval boundscheck() = true
+    end
+    #     # @require LoopVectorization="bdcacae8-1622-11e9-2a5c-532679323890" @eval using StrideArrays
   end
-  #     # @require LoopVectorization="bdcacae8-1622-11e9-2a5c-532679323890" @eval using StrideArrays
 end
 
 end

--- a/src/ptr_array.jl
+++ b/src/ptr_array.jl
@@ -886,7 +886,12 @@ Base.@propagate_inbounds function Base.setindex!(
     PtrArray(A)[i...] = v
   end
 end
-boundscheck() = false
+if checkbounds_recompile
+  @eval boundscheck() = $(Base.JLOptions().check_bounds == 1)
+else
+  boundscheck() = false
+end
+
 @inline function Base.getindex(A::PtrArray, i::Vararg{Integer})
   boundscheck() && @boundscheck checkbounds(A, i...)
   pload(_offset_ptr(stridedpointer(A), i))


### PR DESCRIPTION
for the standard use case (julia v1.9+ and pkgimages) the precompile files are specialized on `--check-bounds` so the choice can be done at precompilation time
