### PR TITLE
Remove automatic inbounds stuff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StrideArraysCore"
 uuid = "7792a7ef-975c-4747-a70f-980b88e8d1da"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.4.17"
+version = "0.5.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/README.md
+++ b/README.md
@@ -5,16 +5,6 @@
 [![Build Status](https://github.com/JuliaSIMD/StrideArraysCore.jl/workflows/CI/badge.svg)](https://github.com/JuliaSIMD/StrideArraysCore.jl/actions)
 [![Coverage](https://codecov.io/gh/JuliaSIMD/StrideArraysCore.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaSIMD/StrideArraysCore.jl)
 
-### Caution
-
-`StrideArraysCore` (and `StrideArray`s) does not check bounds by default. To enable bounds checking (for both), define
-```julia
-StrideArraysCore.boundscheck() = true
-```
-Note, bounds checking is still disabled when using `@inbounds`, even if `boundscheck() == false`.
-Starting Julia with `--check-bounds=yes` will automatically redefine `StrideArraysCore.boundscheck() = true`.
-
-
 Defines the core `PtrArray` type so that some libraries can make use of it internally without the need for circular dependencies.
 [StrideArrays](https://github.com/chriselrod/StrideArrays.jl) extends this type with many methods and functionality. It is
 recommended you depend on and use `StrideArrays` instead.

--- a/src/StrideArraysCore.jl
+++ b/src/StrideArraysCore.jl
@@ -48,8 +48,6 @@ export PtrArray, StrideArray, StaticInt, static, @gc_preserve
   (r::Returns)(args...) = r.x
 end
 
-const checkbounds_recompile = VERSION >= v"1.9.0" && Base.JLOptions().use_pkgimages == 1
-
 @generated static_sizeof(::Type{T}) where {T} =
   :(StaticInt{$(Base.allocatedinline(T) ? sizeof(T) : sizeof(Int))}())
 include("ptr_array.jl")
@@ -68,14 +66,5 @@ if VERSION >= v"1.7.0" && hasfield(Method, :recursion_relation)
   end
 end
 
-if !checkbounds_recompile
-  function __init__()
-    ccall(:jl_generating_output, Cint, ()) == 1 && return nothing
-    if Base.JLOptions().check_bounds == 1
-      @eval boundscheck() = true
-    end
-    #     # @require LoopVectorization="bdcacae8-1622-11e9-2a5c-532679323890" @eval using StrideArrays
-  end
-end
 
 end

--- a/src/ptr_array.jl
+++ b/src/ptr_array.jl
@@ -891,11 +891,6 @@ Base.@propagate_inbounds function Base.setindex!(
     PtrArray(A)[i...] = v
   end
 end
-if checkbounds_recompile
-  @eval boundscheck() = $(Base.JLOptions().check_bounds == 1)
-else
-  boundscheck() = false
-end
 
 @inline _offset_dense(i::Tuple{}, s::Tuple{}) = Zero()
 @inline _offset_dense(i::Tuple{I}, s::Tuple{S}) where {I,S} = i[1] * s[1]
@@ -937,32 +932,32 @@ end
 end
 
 @inline function Base.getindex(A::PtrArray, i::Vararg{Integer})
-  boundscheck() && @boundscheck checkbounds(A, i...)
+  @boundscheck checkbounds(A, i...)
   pload(_offset_ptr(A, i))
 end
 @inline function Base.setindex!(A::PtrArray, v, i::Vararg{Integer,K}) where {K}
-  boundscheck() && @boundscheck checkbounds(A, i...)
+  @boundscheck checkbounds(A, i...)
   pstore!(_offset_ptr(A, i), v)
   v
 end
 @inline function Base.getindex(A::PtrArray{T}, i::Integer) where {T}
-  boundscheck() && @boundscheck checkbounds(A, i)
+  @boundscheck checkbounds(A, i)
   pload(pointer(A) + (i - oneunit(i)) * static_sizeof(T))
 end
 @inline function Base.setindex!(A::PtrArray{T}, v, i::Integer) where {T}
-  boundscheck() && @boundscheck checkbounds(A, i)
+  @boundscheck checkbounds(A, i)
   pstore!(pointer(A) + (i - oneunit(i)) * static_sizeof(T), v)
   v
 end
 @inline function Base.getindex(A::PtrVector{T}, i::Integer) where {T}
-  boundscheck() && @boundscheck checkbounds(A, i)
+  @boundscheck checkbounds(A, i)
   pload(
     pointer(A) +
     (i - ArrayInterface.offset1(A)) * only(LayoutPointers.bytestrides(A))
   )
 end
 @inline function Base.setindex!(A::PtrVector{T}, v, i::Integer) where {T}
-  boundscheck() && @boundscheck checkbounds(A, i)
+  @boundscheck checkbounds(A, i)
   pstore!(
     pointer(A) +
     (i - ArrayInterface.offset1(A)) * only(LayoutPointers.bytestrides(A)),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,7 +77,6 @@ end
   Aqua.test_all(StrideArraysCore)
 
   @testset "StrideArrays Basic" begin
-    @test (Base.JLOptions().check_bounds == 1) == StrideArraysCore.boundscheck()
 
     Acomplex = StrideArray{Complex{Float64}}(undef, (StaticInt(4), StaticInt(5)))
     @test @inferred(StrideArraysCore.ArrayInterface.known_size(Acomplex)) === (4, 5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,8 +73,8 @@ end
 end
 
 @testset "StrideArraysCore.jl" begin
-
-  Aqua.test_all(StrideArraysCore)
+  # Currently StrideArraysCore commits piracy with zero_offsets(A::AbstractArray) and preserve_buffer(A::MemoryBuffer)
+  Aqua.test_all(StrideArraysCore; piracy=false) 
 
   @testset "StrideArrays Basic" begin
 


### PR DESCRIPTION
Ref: https://github.com/JuliaSIMD/StrideArrays.jl/issues/80

This PR takes the approach of just nuking the `StrideArraysCore.checkbounds` function entirely. If preferred though, I can change it so that it still exists but befaults to `true`.

Another thing we could do to avoid making this a breaking release is we could just define a stub
```julia
function checkbounds end
```
so that code in other packages that try and turn boundschecks on or off continues to function

_____________

Note: I haven't yet done any sort of audit yet to see if there are functions or chunks of code which could safely be marked inbounds but currently aren't due to the default being no bounds checks. 