### PR TITLE
Fix for Static.jl v1.4

### DIFF
--- a/src/ptr_array.jl
+++ b/src/ptr_array.jl
@@ -969,7 +969,7 @@ end
   A isa AbstractVector && return _offset_ptr(A, (first(i),))
   p = pointer(A)
   j = map(-, i, offsets(A))
-  if all(dense_dims(A))
+  if all(Bool, dense_dims(A))
     R = stride_rank_val(A)
     _offset_ptr_dense(p, invpermtuple(j, R), invpermtuple(static_size(A), R))
   else


### PR DESCRIPTION
Static.jl removed `Base.all` on tuples of `Static.True()`/`Static.False()` in https://github.com/SciML/Static.jl/pull/163, which breaks StridedArraysCore.jl, see https://github.com/SciML/Static.jl/pull/163#issuecomment-4339683224. This fixes it again.
@ChrisRackauckas IIUC, it still statically infers:
```julia
julia> using StrideArraysCore

julia> using Static, StaticArrayInterface

julia> A = PtrArray(pointer(ones(4, 4)), (static(4), static(4)))
4×4 PtrArray{Float64, 2, (1, 2), Tuple{StaticInt{4}, StaticInt{4}}, Tuple{Nothing, Nothing}, Tuple{StaticInt{1}, StaticInt{1}}} with indices static(1):static(4)×static(1):static(4):
 1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0

julia> @code_typed StrideArraysCore._offset_ptr(A, (1, 1))
CodeInfo(
1 ─       nothing::Nothing
│   %2  =   builtin StrideArraysCore.getfield(A, :ptr)::Ptr{Float64}
│   %3  = $(Expr(:boundscheck, true))::Bool
│   %4  =   builtin Base.getfield(i, 1, %3)::Int64
│   %5  = intrinsic Base.sub_int(%4, 1)::Int64
│   %6  = $(Expr(:boundscheck, true))::Bool
│   %7  =   builtin Base.getfield(i, 2, %6)::Int64
│   %8  = intrinsic Base.sub_int(%7, 1)::Int64
│   %9  = intrinsic Base.mul_int(%8, 4)::Int64
│   %10 = intrinsic Base.add_int(%5, %9)::Int64
│   %11 = intrinsic Base.mul_int(8, %10)::Int64
│   %12 = intrinsic Base.bitcast(UInt64, %11)::UInt64
│   %13 = intrinsic Base.add_ptr(%2, %12)::Ptr{Float64}
└──       return %13
) => Ptr{Float64}
```